### PR TITLE
DATAGO-1506: Removed extra image on tutorial

### DIFF
--- a/docs/_tutorials/topic-to-queue-mapping.md
+++ b/docs/_tutorials/topic-to-queue-mapping.md
@@ -7,8 +7,6 @@ icon: I_dev_topic2q.svg
 
 This tutorial builds on the basic concepts introduced in [Persistence with Queues]({{ site.baseurl }}/persistence-with-queues) tutorial and will show you how to make use of one of Solace’s advanced queueing features called “Topic to Queue Mapping.”
 
-![]({{ site.baseurl }}/images/topic-to-queue-mapping.png)
-
 In addition to spooling messages published directly to the queue, it is possible to add one or more topic subscriptions to a durable queue so that messages published to those topics are also delivered to and spooled by the queue. This is a powerful feature that enables queues to participate equally in point to point and publish / subscribe messaging models. More details about the [“Topic to Queue Mapping” feature here]({{ site.docs-topic-mapping }}){:target="_top"}.
 
 The following diagram illustrates this feature.


### PR DESCRIPTION
Removed an extra picture for messaging and queuing on cloud and dev samples for solace JMS1.1 (Topic to Queue Mapping)