### PR TITLE
Update the solace-opentelemetry-jms-integration to v1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,13 +60,11 @@ dependencies {
     implementation group: 'org.apache.logging.log4j', name: 'log4j-jcl', version: '2.17.1'
 
     //OpenTelemetry dependency
-    implementation group: 'io.opentelemetry', name: 'opentelemetry-api', version: '1.19.0'
-    implementation group: 'io.opentelemetry', name: 'opentelemetry-sdk', version: '1.19.0'
-    implementation group: 'io.opentelemetry', name: 'opentelemetry-exporter-otlp', version: '1.19.0'
-    implementation group: 'io.opentelemetry', name: 'opentelemetry-semconv', version: '1.19.0-alpha'
+    implementation group: 'io.opentelemetry', name: 'opentelemetry-exporter-otlp', version: '1.29.0'
+    implementation group: 'io.opentelemetry', name: 'opentelemetry-semconv', version: '1.29.0-alpha'
 
     //Solace OpenTelemetry Integration for JMS
-    implementation group: 'com.solace', name: 'solace-opentelemetry-jms-integration', version: '1.0.0'
+    implementation group: 'com.solace', name: 'solace-opentelemetry-jms-integration', version: '1.1.0'
 
     // For any local libs that are not available from mavenCentral
     implementation fileTree(dir: 'libs', include: ['*.jar'])


### PR DESCRIPTION
Update the solace-opentelemetry-jms-integration to v1.1.0 and update the related OpenTelemetry dependencies versions.